### PR TITLE
Fix repeated query in ProdDBClient

### DIFF
--- a/dashboard/db/prod_client.py
+++ b/dashboard/db/prod_client.py
@@ -38,11 +38,9 @@ class ProdDBClient(DBClientInterface):
             query_builder = query_builder.limit(limit)
         if maybe_single:
             query_builder = query_builder.maybe_single()
-            response = query_builder.execute()
-            if response is None:
-                return None
         elif single:
             query_builder = query_builder.single()
+
         response = query_builder.execute()
         return response.data
 


### PR DESCRIPTION
## Summary
- avoid double execution for maybe_single selects in ProdDBClient

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6840071109a883209664bb3445fca7ff